### PR TITLE
Add navigation link to My Account page header for improved user navigation

### DIFF
--- a/jobsdoor360-website/src/main/ejs/main-files/myaccount/index.ejs
+++ b/jobsdoor360-website/src/main/ejs/main-files/myaccount/index.ejs
@@ -133,7 +133,7 @@
     <div class="container mt-1">
       <div class="card-section">
         <div class="bg-white px-3 py-3 d-flex align-items-center justify-content-between ">
-          <i class="bi bi-arrow-left-short fs-3 text-dark"></i>
+          <a href="/" class="text-decoration-none"><i class="bi bi-arrow-left-short fs-3 text-dark"></i></a>
           <h5 class="mb-0">My Account</h5>
           <span style="width: 24px;"></span> <!-- Spacer to balance arrow icon -->
         </div>        <!-- Profile -->

--- a/myaccount/index.html
+++ b/myaccount/index.html
@@ -307,7 +307,7 @@
     <div class="container mt-1">
       <div class="card-section">
         <div class="bg-white px-3 py-3 d-flex align-items-center justify-content-between ">
-          <i class="bi bi-arrow-left-short fs-3 text-dark"></i>
+          <a href="/" class="text-decoration-none"><i class="bi bi-arrow-left-short fs-3 text-dark"></i></a>
           <h5 class="mb-0">My Account</h5>
           <span style="width: 24px;"></span> <!-- Spacer to balance arrow icon -->
         </div>        <!-- Profile -->


### PR DESCRIPTION
This pull request updates the "My Account" page in both `index.ejs` and `index.html` files to make the back arrow icon functional by wrapping it in a link that redirects users to the homepage.

Navigation improvement:

* [`jobsdoor360-website/src/main/ejs/main-files/myaccount/index.ejs`](diffhunk://#diff-726105343edda166bed6799e77707455634348cc7e472278261068a9cdf69fb4L136-R136): Updated the back arrow icon to be wrapped in an anchor tag linking to the homepage (`"/"`).
* [`myaccount/index.html`](diffhunk://#diff-f55619eaff9820f11f683c298b46800dd5e07b136960be18ae95d5ab72391c9fL310-R310): Applied the same change to the back arrow icon, wrapping it in a link to the homepage (`"/"`).