### PR TITLE
Clear profile name in my account page for privacy reasons

### DIFF
--- a/jobsdoor360-website/src/main/ejs/main-files/myaccount/index.ejs
+++ b/jobsdoor360-website/src/main/ejs/main-files/myaccount/index.ejs
@@ -131,7 +131,7 @@
         <div class="d-flex align-items-center mb-4">
           <img src="https://static.vecteezy.com/system/resources/previews/005/544/718/non_2x/profile-icon-design-free-vector.jpg" alt="Profile" class="profile-img me-3" />
           <div>
-            <h5 class="mb-0">John Smith</h5>
+            <h5 class="mb-0"></h5>
           </div>
         </div>
     


### PR DESCRIPTION
This pull request includes a small change to the `index.ejs` file in the `myaccount` section of the website. The change removes the placeholder name "John Smith" from the profile header, leaving the `<h5>` element empty.